### PR TITLE
Handle case where Google profile photo already contains a resize option to avoid getting http 400 code

### DIFF
--- a/api/commenter_photo.go
+++ b/api/commenter_photo.go
@@ -21,7 +21,7 @@ func commenterPhotoHandler(w http.ResponseWriter, r *http.Request) {
 	if c.Provider == "google" {
 		if strings.HasSuffix(url, "photo.jpg") {
 			url += "?sz=38"
-		} else {
+		} else if !strings.Contains(url, "=s") {
 			url += "=s38"
 		}
 	} else if c.Provider == "github" {


### PR DESCRIPTION
Adding in any case a size attribute "=s38" results in some cases in a HTTP 400 error. Patch applied allows to add size parameter only if it is not already present in the URL.