### PR TITLE
[FIX] access_token query param in query string is deprecated. Token has to be passed as Authorization header

### DIFF
--- a/api/oauth_github_callback.go
+++ b/api/oauth_github_callback.go
@@ -9,7 +9,15 @@ import (
 )
 
 func githubGetPrimaryEmail(accessToken string) (string, error) {
-	resp, err := http.Get("https://api.github.com/user/emails?access_token=" + accessToken)
+
+	// resp, err := http.Get("https://api.github.com/user/emails?access_token=" + accessToken)
+
+	// https://gitlab.com/commento/commento/-/merge_requests/176/diffs?commit_id=7e9c118c969d2bbc82bea4fe34786c6eb999aee1
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.github.com/user/emails", nil)
+	req.Header.Add("Authorization", "token " + accessToken)
+	resp, err := client.Do(req)
+
 	defer resp.Body.Close()
 
 	contents, err := ioutil.ReadAll(resp.Body)
@@ -56,7 +64,14 @@ func githubCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := http.Get("https://api.github.com/user?access_token=" + token.AccessToken)
+	// resp, err := http.Get("https://api.github.com/user?access_token=" + token.AccessToken)
+
+	// https://gitlab.com/commento/commento/-/merge_requests/176/diffs?commit_id=7e9c118c969d2bbc82bea4fe34786c6eb999aee1
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	req.Header.Add("Authorization", "token " + token.AccessToken)
+	resp, err := client.Do(req)
+
 	if err != nil {
 		fmt.Fprintf(w, "Error: %s", err.Error())
 		return


### PR DESCRIPTION
Github does not accept anymore access_token to be passed as a query string parameter. It has to be passed as a header (Authorization header)